### PR TITLE
Add support for GNOME 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "uuid": "focus-follows-workspace@christopher.luebbemeier.gmail.com",
   "version": 1,
   "shell-version": [
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/christopher-l/focus-follows-workspace"
 }


### PR DESCRIPTION
It was enough to just add the version number 42 to get it to work on my installation of Ubuntu 22.04

Thanks btw for taking the time to create this simple but crucial extension in the first place!