### PR TITLE
Include support for GNOME 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "uuid": "focus-follows-workspace@christopher.luebbemeier.gmail.com",
   "version": 9,
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "settings-schema": "org.gnome.shell.extensions.focus-follows-workspace",
   "url": "https://github.com/christopher-l/focus-follows-workspace"


### PR DESCRIPTION
I made this change locally and all appears to be working in GNOME 46 now.

I'm afraid I don't know much about how GNOME extensions work, but I'm hoping this fixes things for everyone.